### PR TITLE
fix installation issues

### DIFF
--- a/kinesis/__init__.py
+++ b/kinesis/__init__.py
@@ -1,4 +1,3 @@
 from .mock import *
 from .utils import *
-from .data import *
 from .models import *

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     author=AUTHOR,
     author_email=EMAIL,
     packages=find_packages(exclude=("tests",)),
-    install_requires=["astropy", "arviz", "pystan==2.18"],
+    package_data={'kinesis': ['stan/*.stan']},
+    install_requires=["astropy", "arviz", "pystan"],
 )


### PR DESCRIPTION
These are some minor changes that should fix installation. I could not install kinesis after cloning the repository right away:

* I removed the `data` import, as I guess there used to be a module or file called like this but it was removed.
* I added the folder with the stan code to the package data, otherwise, the fitter object could not find the codes once installed.

I also did not see on a _very_ quick look anything forcing to pin on pystan 2.18, so I removed that, but it has nothing to do with installation issues and I could be completely wrong, it was a very quick look. 